### PR TITLE
Warn and exit on known bad pipe stop

### DIFF
--- a/runasp.py
+++ b/runasp.py
@@ -574,6 +574,10 @@ if __name__ == '__main__':
     if opt.code_version:
         print VERSION
         sys.exit(0)
+    if opt.pipe_stop_before == 'create_props_files':
+        print """There is a known bug in flt_pctr that can prevent
+a stop at 'create_props_files'.  Choose a different pipe stop."""
+        sys.exit(0)
     logger = pyyaks.logger.get_logger(name='runasp', level=opt.log_level, filename=opt.log_file,
                                       filelevel=15, format="%(asctime)s %(message)s")
     main(opt)


### PR DESCRIPTION
Warn and exit if 'create_props_files' is given as a pipe at which to stop.
There is a known bug in flt_pctr that can cause the pipes to continue instead of stopping for this one pipe. 
