### PR TITLE
Add code to make a stars.txt file if missing

### DIFF
--- a/runasp.py
+++ b/runasp.py
@@ -14,6 +14,7 @@ from Ska.Shell import getenv, bash, tcsh_shell, ShellError
 import pyyaks.logger
 from astropy.io import fits
 from astropy.table import Table
+from mica.starcheck import get_starcheck_catalog_at_date
 
 _versionfile = os.path.join(os.path.dirname(__file__), 'VERSION')
 VERSION = open(_versionfile).read().strip()
@@ -379,7 +380,6 @@ def mock_stars_file(opt, ai):
     """
     Mock up the stars.txt file if one was not made automatically
     """
-    from mica.starcheck import get_starcheck_catalog_at_date
     sc = get_starcheck_catalog_at_date(ai['istart'])
 
     acqs = sc['cat'][(sc['cat']['type'] == 'ACQ') | (sc['cat']['type'] == 'BOT')]

--- a/runasp.py
+++ b/runasp.py
@@ -423,8 +423,8 @@ def mock_cai_file(opt):
     acq = np.flatnonzero(ai_rec['aspect_mode'] == 'ACQUISITION')
     gui = np.flatnonzero(ai_rec['aspect_mode'] == 'GUIDE')
     if len(acq) and len(gui):
-        kalman_mask = ((np.arange(len(ai_rec)) > acq)
-                       & (np.arange(len(ai_rec)) > gui)
+        kalman_mask = ((np.arange(len(ai_rec)) > np.max(acq))
+                       & (np.arange(len(ai_rec)) > np.max(gui))
                        & (ai_rec['pcad_mode'] == 'NPNT')
                        & (ai_rec['aspect_mode'] == 'KALMAN'))
         kalman = ai_rec[kalman_mask]

--- a/runasp.py
+++ b/runasp.py
@@ -397,6 +397,8 @@ def mock_stars_file(opt, ai):
     gui['soe_type'] = 1
     for g in gui[['slot', 'soe_type', 'id', 'yang', 'zang']]:
         full_table.add_row(g)
+    # If we have no stars.txt file, this should be an ER and we shouldn't need
+    # to care about the instrument anyway.
     instr = 'HRC-S' if sc['obs']['sci_instr'] is None else sc['obs']['sci_instr']
     full_table['instr'] = instr
     full_table.write(os.path.join(ai['outdir'], "pcad{}_stars.txt".format(ai['root'])),


### PR DESCRIPTION
Add code to make a stars.txt file if missing.

This uses the mica starcheck table as the reference for the stars by the date of the start of the interval being processed.  This should only come up on ERs that (for whatever reason) don't have entries in the CXCDS stars table.